### PR TITLE
Remove invalid file/directory attributes

### DIFF
--- a/DokanPbo.Core/PboFSNode.cs
+++ b/DokanPbo.Core/PboFSNode.cs
@@ -157,7 +157,7 @@ namespace DokanPbo
             parent = inputParent;
             FileInformation = new DokanNet.FileInformation()
             {
-                Attributes = System.IO.FileAttributes.Directory | FileAttributes.Temporary | FileAttributes.Archive,
+                Attributes = System.IO.FileAttributes.Directory,
                 FileName = name,
                 LastAccessTime = DateTime.Now,
                 LastWriteTime = DateTime.Now,
@@ -177,7 +177,7 @@ namespace DokanPbo
             parent = inputParent;
             FileInformation = new DokanNet.FileInformation()
             {
-                Attributes = System.IO.FileAttributes.Normal | FileAttributes.ReadOnly | FileAttributes.Temporary | FileAttributes.Archive,
+                Attributes = System.IO.FileAttributes.Normal | FileAttributes.ReadOnly,
                 FileName = name,
                 Length = (long)file.DataSize,
                 LastAccessTime = DateTime.Now,


### PR DESCRIPTION
The attributes don't make sense and actually break stuff.
Archive flag is intended for backup programs, if the flag is set that means someone edited the file since the last backup.
Temporary flag marks files which when written into are temporary and don't ever have to hit disk and can stay in ram and be deleted when their last handle is gone, which doesn't make any sense for us.
Temporary flag on directory broke directory copying out of DokanPbo drive, I don't even think temp flag on directory is valid.