### PR TITLE
Fix setEof/setFileTime exceptions

### DIFF
--- a/DokanPbo.Core/PboFS.cs
+++ b/DokanPbo.Core/PboFS.cs
@@ -222,16 +222,6 @@ namespace DokanPbo
                                 folder.Children[FileNameDirectNoLeadingSlash.ToLower()] = rlFile;
                                 fileTree.AddNode(rlFile);
                                 info.Context = rlFile;
-
-                                //If it wants to immediately write to file, we have to open it here already.
-                                //if ((access & (FileAccess.WriteData | FileAccess.AppendData | FileAccess.Delete |
-                                //               FileAccess.GenericWrite)) != 0)
-                                //    rlFile.Open(true, System.IO.FileMode.Open); 
-                                ////same for reading
-                                //if ((access & (FileAccess.ReadData | FileAccess.GenericRead | FileAccess.Execute |
-                                //               FileAccess.GenericExecute)) != 0)
-                                //    rlFile.Open(false, System.IO.FileMode.Open);
-
                             }
 
                             return DokanResult.Success;

--- a/DokanPbo.Core/PboFS.cs
+++ b/DokanPbo.Core/PboFS.cs
@@ -97,7 +97,7 @@ namespace DokanPbo
 
         private IPboFsNode GetNodeFast(string filename, DokanFileInfo info)
         {
-            if (info.Context is IPboFsNode node)
+            if (info?.Context is IPboFsNode node)
                 return node;
             return FindNode(filename);
         }

--- a/DokanPbo.Core/PboFS.cs
+++ b/DokanPbo.Core/PboFS.cs
@@ -222,6 +222,16 @@ namespace DokanPbo
                                 folder.Children[FileNameDirectNoLeadingSlash.ToLower()] = rlFile;
                                 fileTree.AddNode(rlFile);
                                 info.Context = rlFile;
+
+                                //If it wants to immediately write to file, we have to open it here already.
+                                //if ((access & (FileAccess.WriteData | FileAccess.AppendData | FileAccess.Delete |
+                                //               FileAccess.GenericWrite)) != 0)
+                                //    rlFile.Open(true, System.IO.FileMode.Open); 
+                                ////same for reading
+                                //if ((access & (FileAccess.ReadData | FileAccess.GenericRead | FileAccess.Execute |
+                                //               FileAccess.GenericExecute)) != 0)
+                                //    rlFile.Open(false, System.IO.FileMode.Open);
+
                             }
 
                             return DokanResult.Success;
@@ -560,6 +570,8 @@ namespace DokanPbo
 
             if (node is PboFsRealFile file)
             {
+                //#TODO we can't do this while file is open. Optimally we just want to queue tasks to be executed once the file is closed.
+                if (file.IsOpenForWriting) return DokanResult.Success;
                 if (ctime != null)
                 {
                     System.IO.File.SetCreationTime(file.GetRealPath(), ctime.Value);

--- a/DokanPbo.Core/PboFSNode.cs
+++ b/DokanPbo.Core/PboFSNode.cs
@@ -1,4 +1,4 @@
-﻿using DokanNet;
+using DokanNet;
 using SwiftPbo;
 using System;
 using System.Collections.Generic;
@@ -277,9 +277,10 @@ namespace DokanPbo
     {
         public System.IO.FileInfo file;
         private bool? wantsOpenWrite;
-        private FileMode openMode;
+        private FileMode openMode = FileMode.Open;
         private System.IO.FileStream readStream = null;
         private System.IO.FileStream writeStream = null;
+        public bool IsOpenForWriting => writeStream != null;
 
         //In case someone tries to set lastWriteTime while we have a Write stream open.
         private DateTime? lastWriteTimeTodo;
@@ -300,6 +301,7 @@ namespace DokanPbo
             };
         }
 
+        //writeableStream is from newly created file
         public PboFsRealFile(System.IO.FileInfo inputFile, PboFsFolder inputParent, System.IO.FileStream writeableStream) : this(inputFile, inputParent)
         {
             writeStream = writeableStream;


### PR DESCRIPTION
Fixed Exception when setEof is called on not yet opened file (Happens when for example extracting a zip archive onto dokan drive)
Fixed Exception on setFileTime on currently opened file (Happens when for example extracting a zip archive onto dokan drive)